### PR TITLE
Set User-Agent header on request.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -211,6 +211,7 @@ export default class Toucan {
   private postEvent(data: Event) {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
+      "User-Agent": "__name__/__version__",
     };
 
     return fetch(this.url, {


### PR DESCRIPTION
The fetch API in Cloudflare Workers doesnt't set user-agent. Older versions of self-hosted sentry get client name & version from URL query string parameter `sentry_client` and fall back to User-Agent header; if neither is present, POST fails.

Setting User-Agent on outgoing POST makes it work.