### PR TITLE
v1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toucan-js",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Cloudflare Workers client for Sentry",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
### Set User-Agent header on request
Now sending `User-Agent` header set to "__name__/__version__" to be compatible with older versions of self-hosted sentry.