### PR TITLE
Source map improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toucan-js",
-  "version": "1.2.1",
+  "version": "1.3.0-rc.1",
   "description": "Cloudflare Workers client for Sentry",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,8 @@ export type Options = {
   allowedHeaders?: string[] | RegExp;
   allowedCookies?: string[] | RegExp;
   allowedSearchParams?: string[] | RegExp;
+  attachStacktrace?: SentryOptions["attachStacktrace"];
+  sourceMapUrlPrefix?: string;
 };
 
 export type Level = "fatal" | "error" | "warning" | "info" | "debug";


### PR DESCRIPTION
### Source Maps improvements

#### Features
- new `attachStacktrace` option - Attaches stacktraces to pure capture message / log integrations. Default: true.
- new `sourceMapUrlPrefix` option - sentry-cli and webpack-sentry-plugin upload the source-maps named by their path with a ~/ prefix. Toucan will adhere to this behaviour, so default configurations will properly match. Default: `~/`.

#### Bugfixes
- Stack traces are now reversed as expected by Sentry.