### PR TITLE
`transportOptions` to pass custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ async function doStuff(event: FetchEvent, sentry: Toucan) {
 | allowedCookies      | string[] \| RegExp      | Array of allowed cookies, or a regular expression used to explicitly allow cookies of incoming request. If not provided, cookies will not be logged.                   |
 | allowedSearchParams | string[] \| RegExp      | Array of allowed search params, or a regular expression used to explicitly allow search params of incoming request. If not provided, search params will not be logged. |
 | beforeSend          | (event: Event) => Event | This function is applied to all events before sending to Sentry. If provided, all allowlists are ignored.                                                              |
+| transportOptions        | { dsn: string, headers: Record<string, string> } | Custom headers to be passed to Sentry. DSN is to be defined here on use |
 
 ## Sensitive data
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ import {
 } from "@sentry/types";
 
 export type Options = {
-  dsn: NonNullable<SentryOptions["dsn"]>;
+  dsn: SentryOptions["dsn"];
   event: FetchEvent;
   environment?: SentryOptions["environment"];
   release?: SentryOptions["release"];
@@ -16,6 +16,7 @@ export type Options = {
   allowedSearchParams?: string[] | RegExp;
   attachStacktrace?: SentryOptions["attachStacktrace"];
   sourceMapUrlPrefix?: string;
+  transportOptions?: SentryOptions["transportOptions"];
 };
 
 export type Level = "fatal" | "error" | "warning" | "info" | "debug";

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ import {
 } from "@sentry/types";
 
 export type Options = {
-  dsn: SentryOptions["dsn"];
+  dsn?: SentryOptions["dsn"];
   event: FetchEvent;
   environment?: SentryOptions["environment"];
   release?: SentryOptions["release"];

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Toucan DSN with transportOptions 1`] = `
+Object {
+  "breadcrumbs": Array [],
+  "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
+  "level": "info",
+  "logger": "EdgeWorker",
+  "message": "test",
+  "platform": "node",
+  "request": Object {
+    "method": "GET",
+    "url": "https://example.com/",
+  },
+  "sdk": Object {
+    "name": "__name__",
+    "version": "__version__",
+  },
+  "timestamp": 1586752837.868,
+}
+`;
+
+exports[`Toucan DSN with transportOptions 2`] = `"651b177fe1cb4ac89e15c1ecd2cb1d0a"`;
+
 exports[`Toucan allowlists 1`] = `
 Object {
   "breadcrumbs": Array [],


### PR DESCRIPTION
This PR adds the ability to define custom headers to be passed by Toucan to Sentry.

Example
```javascript
const toucan = new Toucan({
  transportOptions: {
    dsn: A_DSN,
    headers: {
      'X-Custom-Header': '1',
    },
  },
  event,
})
```