### PR TITLE
Add option to override file name in stack trace to allow multiple scripts built from one code base

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -476,7 +476,7 @@ export default class Toucan {
       return {
         frames: stack
           .map<StackFrame>((frame) => {
-            const filename = frame.fileName ?? "";
+            const filename = this.options.stacktraceFileName ?? frame.fileName ?? "";
             return {
               colno: frame.columnNumber,
               lineno: frame.lineNumber,

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export type Options = {
   allowedSearchParams?: string[] | RegExp;
   attachStacktrace?: SentryOptions["attachStacktrace"];
   sourceMapUrlPrefix?: string;
+  stacktraceFileName?: string;
 };
 
 export type Level = "fatal" | "error" | "warning" | "info" | "debug";


### PR DESCRIPTION
I build multiple scripts from single repository using Webpack (multiple entry points, multiple bundles, one map file per bundle). Cloudflare hardcodes filename in stack trace to `worker.js`, which makes it impossible to distinguish which source/map from a release should be used.

This PR adds option to override source name.

Note: I am still not able to get Sentry to use the source map, even if it's uploaded to a release together with the source. This might be another case of needing to use older API or format, as this is a self-hosted Sentry 9.1.2. I'd be happy to hear any suggestions and will continue to figure it out, but this PR seems to be needed in any case.