### PR TITLE
remove dsn from transportOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,6 @@ import {
   isPlainObject,
   extractExceptionKeysForMessage,
   normalizeToSize,
-  Dsn,
 } from "@sentry/utils";
 import { v4 as uuidv4 } from "uuid";
 import { parse } from "cookie";
@@ -58,15 +57,6 @@ export default class Toucan {
   private extra?: Record<string, string>;
 
   constructor(options: Options) {
-    if (options.transportOptions) {
-      // options.transportOptions.dsn is either a string or a Dsn object
-      const dsn = options.transportOptions.dsn;
-      if (dsn instanceof Dsn) {
-        options.dsn = dsn.toString();
-      } else {
-        options.dsn = <string>dsn;
-      }
-    }
     if (!options.dsn || options.dsn.length === 0) {
       // If an empty DSN is passed, we should treat it as valid option which signifies disabling the SDK.
       this.url = "";

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,9 @@ export type Options = {
   allowedCookies?: string[] | RegExp;
   allowedSearchParams?: string[] | RegExp;
   attachStacktrace?: SentryOptions["attachStacktrace"];
-  transportOptions?: SentryOptions["transportOptions"];
+  transportOptions?: Compute<
+    Pick<NonNullable<SentryOptions["transportOptions"]>, "headers">
+  >;
   rewriteFrames?: RewriteFrames;
 };
 

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -1,27 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Toucan DSN with transportOptions 1`] = `
-Object {
-  "breadcrumbs": Array [],
-  "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
-  "level": "info",
-  "logger": "EdgeWorker",
-  "message": "test",
-  "platform": "node",
-  "request": Object {
-    "method": "GET",
-    "url": "https://example.com/",
-  },
-  "sdk": Object {
-    "name": "__name__",
-    "version": "__version__",
-  },
-  "timestamp": 1586752837.868,
-}
-`;
-
-exports[`Toucan DSN with transportOptions 2`] = `"651b177fe1cb4ac89e15c1ecd2cb1d0a"`;
-
 exports[`Toucan allowlists 1`] = `
 Object {
   "breadcrumbs": Array [],

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -99,34 +99,11 @@ describe("Toucan", () => {
     expect(result).toMatchSnapshot();
   });
 
-  test("DSN with transportOptions", async () => {
-    let result: string | undefined = undefined;
-    self.addEventListener("fetch", (event) => {
-      const toucan = new Toucan({
-        transportOptions: {
-          dsn: VALID_DSN,
-        },
-        event,
-      });
-      result = toucan.captureMessage("test");
-      event.respondWith(new Response("OK", { status: 200 }));
-    });
-
-    await triggerFetchAndWait(self);
-
-    // Expect POST request to Sentry
-    expect(global.fetch).toHaveBeenCalledTimes(1);
-    // Match POST request payload snap
-    expect(getFetchMockPayload(global.fetch)).toMatchSnapshot();
-    // captureMessage should have returned a generated eventId
-    expect(result).toMatchSnapshot();
-  });
-
   test("pass custom headers in transportOptions", async () => {
     self.addEventListener("fetch", (event) => {
       const toucan = new Toucan({
+        dsn: VALID_DSN,
         transportOptions: {
-          dsn: VALID_DSN,
           headers: {
             "X-Custom-Header": "1",
           },


### PR DESCRIPTION
Let's use the root `dsn` for everything to avoid confusion