### PR TITLE
v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toucan-js",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Cloudflare Workers client for Sentry",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
## Remove `dsn` from transportOptions

### Breaking
- `dsn` is no longer part of `transportOptions`. Root `dsn` is the single source of truth for `dsn` settings.

#### Misc
- Upgrade documentation with an example on how to make source maps work.