### PR TITLE
v2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toucan-js",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Cloudflare Workers client for Sentry",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
## Dependency maintenance

- All dependencies have been upgraded to their late
- @types/stacktrace-js removed because the original lib provides the types