### PR TITLE
Migrate internal logic to Scope stack

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@sentry/core": "6.2.3",
     "@sentry/utils": "6.2.3",
     "@sentry/types": "6.2.3",
+    "@sentry/hub": "6.2.3",
     "@types/cookie": "0.4.0",
     "@types/uuid": "8.3.0",
     "cookie": "0.4.1",

--- a/src/scope.ts
+++ b/src/scope.ts
@@ -1,0 +1,54 @@
+/**
+ * Parts of code taken from: https://github.com/getsentry/sentry-javascript/blob/06d6bd87971b22dcaba99b03e1f885158c7dd66f/packages/hub/src/scope.ts
+ */
+import { Scope as SentryScope } from "@sentry/hub";
+import { Breadcrumb, Event } from "./types";
+
+export class Scope extends SentryScope {
+  /**
+   * Sets the breadcrumbs in the scope
+   *
+   * @param breadcrumb
+   * @param maxBreadcrumbs
+   */
+  public addBreadcrumb(
+    breadcrumb: Breadcrumb,
+    maxBreadcrumbs?: number | undefined
+  ) {
+    // Type-casting 'breadcrumb' to any because our level type is a union of literals, as opposed to Level enum.
+    return super.addBreadcrumb(breadcrumb as any, maxBreadcrumbs);
+  }
+
+  /**
+   * Applies the current context to the event.
+   *
+   * @param event Event
+   */
+  public applyToEventSync(event: Event): Event {
+    if (this._extra && Object.keys(this._extra).length) {
+      event.extra = { ...this._extra, ...event.extra };
+    }
+    if (this._tags && Object.keys(this._tags).length) {
+      event.tags = { ...this._tags, ...event.tags };
+    }
+    if (this._user && Object.keys(this._user).length) {
+      event.user = { ...this._user, ...event.user };
+    }
+
+    event.fingerprint = [
+      ...(event.fingerprint ?? []),
+      ...(this._fingerprint ?? []),
+    ];
+    event.fingerprint =
+      event.fingerprint.length > 0 ? event.fingerprint : undefined;
+
+    event.breadcrumbs = [
+      ...(event.breadcrumbs ?? []),
+      ...(this._breadcrumbs ?? []),
+    ];
+    event.breadcrumbs =
+      event.breadcrumbs.length > 0 ? event.breadcrumbs : undefined;
+
+    return event;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,14 @@ export type Options = {
   >;
 };
 
-export type Level = "fatal" | "error" | "warning" | "info" | "debug";
+export type Level =
+  | "critical"
+  | "fatal"
+  | "error"
+  | "warning"
+  | "info"
+  | "log"
+  | "debug";
 // Overwrite default level type of enum to type of union of string literals
 export type Breadcrumb = Compute<
   Omit<SentryBreadcrumb, "level"> & { level?: Level }

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`Toucan FetchEvent allowlists 1`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "level": "info",
   "logger": "EdgeWorker",
@@ -35,7 +34,6 @@ Object {
 
 exports[`Toucan FetchEvent attachStacktrace false 1`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "exception": Object {
     "values": Array [
@@ -64,7 +62,6 @@ exports[`Toucan FetchEvent attachStacktrace false 2`] = `"651b177fe1cb4ac89e15c1
 
 exports[`Toucan FetchEvent beforeSend 1`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "level": "info",
   "logger": "EdgeWorker",
@@ -87,7 +84,6 @@ Object {
 
 exports[`Toucan FetchEvent captureException: Error 1`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "exception": Object {
     "values": Array [
@@ -132,7 +128,6 @@ exports[`Toucan FetchEvent captureException: Error 2`] = `"651b177fe1cb4ac89e15c
 
 exports[`Toucan FetchEvent captureException: Object 1`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "exception": Object {
     "values": Array [
@@ -177,7 +172,6 @@ exports[`Toucan FetchEvent captureException: Object 2`] = `"651b177fe1cb4ac89e15
 
 exports[`Toucan FetchEvent captureException: primitive 1`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "exception": Object {
     "values": Array [
@@ -220,7 +214,6 @@ Object {
 
 exports[`Toucan FetchEvent captureException: primitive 2`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "exception": Object {
     "values": Array [
@@ -263,7 +256,6 @@ Object {
 
 exports[`Toucan FetchEvent captureException: primitive 3`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "exception": Object {
     "values": Array [
@@ -308,7 +300,6 @@ exports[`Toucan FetchEvent captureException: primitive 4`] = `"651b177fe1cb4ac89
 
 exports[`Toucan FetchEvent captureMessage 1`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "level": "info",
   "logger": "EdgeWorker",
@@ -337,7 +328,7 @@ Array [
     "toucan-js: calling captureMessage",
   ],
   Array [
-    "toucan-js: sending request to Sentry with headers: {\\"Content-Type\\":\\"application/json\\",\\"User-Agent\\":\\"__name__/__version__\\"} and body: {\\"event_id\\":\\"651b177fe1cb4ac89e15c1ecd2cb1d0a\\",\\"logger\\":\\"EdgeWorker\\",\\"platform\\":\\"node\\",\\"timestamp\\":1586752837.868,\\"level\\":\\"info\\",\\"breadcrumbs\\":[],\\"message\\":\\"test\\",\\"request\\":{\\"method\\":\\"GET\\",\\"url\\":\\"https://example.com/\\"},\\"sdk\\":{\\"name\\":\\"__name__\\",\\"version\\":\\"__version__\\"}}",
+    "toucan-js: sending request to Sentry with headers: {\\"Content-Type\\":\\"application/json\\",\\"User-Agent\\":\\"__name__/__version__\\"} and body: {\\"event_id\\":\\"651b177fe1cb4ac89e15c1ecd2cb1d0a\\",\\"logger\\":\\"EdgeWorker\\",\\"platform\\":\\"node\\",\\"timestamp\\":1586752837.868,\\"level\\":\\"info\\",\\"message\\":\\"test\\",\\"request\\":{\\"method\\":\\"GET\\",\\"url\\":\\"https://example.com/\\"},\\"sdk\\":{\\"name\\":\\"__name__\\",\\"version\\":\\"__version__\\"}}",
   ],
   Array [
     "toucan-js: http://example.com responded with [200 OK]: OK",
@@ -347,7 +338,6 @@ Array [
 
 exports[`Toucan FetchEvent fingerprint 1`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "exception": Object {
     "values": Array [
@@ -394,7 +384,6 @@ Object {
 
 exports[`Toucan FetchEvent rewriteFrames iteratee 1`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "exception": Object {
     "values": Array [
@@ -441,7 +430,6 @@ exports[`Toucan FetchEvent rewriteFrames iteratee 2`] = `"651b177fe1cb4ac89e15c1
 
 exports[`Toucan FetchEvent rewriteFrames root 1`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "exception": Object {
     "values": Array [
@@ -486,7 +474,6 @@ exports[`Toucan FetchEvent rewriteFrames root 2`] = `"651b177fe1cb4ac89e15c1ecd2
 
 exports[`Toucan FetchEvent setExtra 1`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "extra": Object {
     "foo": "bar",
@@ -509,7 +496,6 @@ Object {
 
 exports[`Toucan FetchEvent setExtras 1`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "extra": Object {
     "bar": "baz",
@@ -533,7 +519,6 @@ Object {
 
 exports[`Toucan FetchEvent setRequestBody 1`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "level": "info",
   "logger": "EdgeWorker",
@@ -557,7 +542,6 @@ Object {
 
 exports[`Toucan FetchEvent setTag 1`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "level": "info",
   "logger": "EdgeWorker",
@@ -580,7 +564,6 @@ Object {
 
 exports[`Toucan FetchEvent setTags 1`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "level": "info",
   "logger": "EdgeWorker",
@@ -604,7 +587,6 @@ Object {
 
 exports[`Toucan FetchEvent setUser 1`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "level": "info",
   "logger": "EdgeWorker",
@@ -628,7 +610,6 @@ Object {
 
 exports[`Toucan ScheduledEvent capture message 1`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "level": "info",
   "logger": "EdgeWorker",
@@ -646,7 +627,6 @@ exports[`Toucan ScheduledEvent capture message 2`] = `"651b177fe1cb4ac89e15c1ecd
 
 exports[`Toucan setRequestBody 1`] = `
 Object {
-  "breadcrumbs": Array [],
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
   "level": "info",
   "logger": "EdgeWorker",


### PR DESCRIPTION
Introducing Scopes, which will allow us to control context properties more conveniently.

There is no change in public API yet.

BREAKING CHANGE
- When there are no breadcrumbs in context, Toucan will not send `breadcrumbs` property to Sentry (was empty array before). This change might break your tests, but it's expected by Sentry, and gets us more aligned with other JS SDKs.