### PR TITLE
Do not require waitUntil in Durable Objects, update docs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -197,8 +197,11 @@ export default class Toucan {
     // This is to maintain backwards compatibility for 'event' option. When we remove it, all this complex logic can go away.
     if ('context' in this.options) {
       this.options.context.waitUntil(this.reportException(event, exception));
-    } else {
+    } else if ('event' in this.options) {
       this.options.event.waitUntil(this.reportException(event, exception));
+    } else {
+      // 'waitUntil' not provided -- this is probably called from within a Durable Object
+      this.reportException(event, exception);
     }
 
     return event.event_id;
@@ -220,8 +223,11 @@ export default class Toucan {
 
     if ('context' in this.options) {
       this.options.context.waitUntil(this.reportMessage(event));
-    } else {
+    } else if ('event' in this.options) {
       this.options.event.waitUntil(this.reportMessage(event));
+    } else {
+      // 'waitUntil' not provided -- this is probably called from within a Durable Object
+      this.reportMessage(event);
     }
 
     return event.event_id;

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,11 @@ type WithContext = {
   request?: Request;
 };
 
+// for Durable Objects
+type WithRequest = {
+  request: Request;
+};
+
 type OtherOptions = {
   dsn?: SentryOptions['dsn'];
   allowedCookies?: string[] | RegExp;
@@ -43,7 +48,10 @@ type OtherOptions = {
   >;
 };
 
-export type Options = (WithEvent & OtherOptions) | (WithContext & OtherOptions);
+export type Options =
+  | (WithEvent & OtherOptions)
+  | (WithContext & OtherOptions)
+  | (WithRequest & OtherOptions);
 
 export type Level =
   | 'critical'

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -82,6 +82,50 @@ Object {
 }
 `;
 
+exports[`Toucan FetchEvent captureException works no "context" or "event" (just calls "fetch") 1`] = `
+Object {
+  "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",
+  "exception": Object {
+    "values": Array [
+      Object {
+        "stacktrace": Object {
+          "frames": Array [
+            Object {
+              "colno": 0,
+              "filename": "~/file",
+              "function": "bar",
+              "lineno": 0,
+            },
+            Object {
+              "colno": 0,
+              "filename": "~/file",
+              "function": "foo",
+              "lineno": 0,
+            },
+          ],
+        },
+        "type": "Error",
+        "value": "test",
+      },
+    ],
+  },
+  "level": "error",
+  "logger": "EdgeWorker",
+  "platform": "node",
+  "request": Object {
+    "method": "GET",
+    "url": "https://example.com/",
+  },
+  "sdk": Object {
+    "name": "__name__",
+    "version": "__version__",
+  },
+  "timestamp": 1586752837.868,
+}
+`;
+
+exports[`Toucan FetchEvent captureException works no "context" or "event" (just calls "fetch") 2`] = `"651b177fe1cb4ac89e15c1ecd2cb1d0a"`;
+
 exports[`Toucan FetchEvent captureException works with "context" (instead of "event") 1`] = `
 Object {
   "event_id": "651b177fe1cb4ac89e15c1ecd2cb1d0a",


### PR DESCRIPTION
You don't need to call `waitUntil` in Durable Objects to extend lifetime -- toucan-js reflects that by not requiring `context`/`event` when `request` is set.

Also updates documentation with some examples.