### PR TITLE
Reapply scope extra for __serialized__

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -561,6 +561,7 @@ export default class Toucan {
       )}`;
 
       this.setExtra('__serialized__', normalizeToSize(maybeError as {}));
+      this.getScope().applyToEvent(event);
 
       error = new Error(message);
     } else {


### PR DESCRIPTION
This fixes missing __serialized__ field in case of "non-error exception".