### PR TITLE
Export useful types from library

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -709,3 +709,5 @@ export default class Toucan {
     return !!this.scopes.pop();
   }
 }
+
+export type { Breadcrumb, Level, Options };


### PR DESCRIPTION
Export useful types from the library, that can be used for a re-usable wrapper for `toucan-js`.

Right now you need to do this:
```ts
import type { Options } from 'toucan-js/dist/types';
```
After this you can do
```ts
import type { Options } from 'toucan-js';
```