### PR TITLE
v2.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toucan-js",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Cloudflare Workers client for Sentry",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
## UUID issues

### Bugfixes
- 3rd party `uuid` lib has been replaced with native `crypto.randomUUID`. This should fix problems when testing `toucan-js` with `jest` (https://github.com/cloudflare/miniflare/issues/256#issuecomment-1137770194). Thank you @e1g for raising in Workers Discord!
