### PR TITLE
Export OtherOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
   Extras,
   Primitive,
 } from '@sentry/types';
-import { Options, Event, Breadcrumb, Level, RewriteFrames } from './types';
+import { Options, OtherOptions, Event, Breadcrumb, Level, RewriteFrames } from './types';
 import { API } from '@sentry/core';
 import {
   isError,
@@ -731,4 +731,4 @@ export default class Toucan {
   }
 }
 
-export type { Breadcrumb, Level, Options };
+export type { Breadcrumb, Level, Options, OtherOptions };

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,7 +36,7 @@ type SamplingContext = {
   request?: SentrySamplingContext['request'];
 };
 
-type OtherOptions = {
+export type OtherOptions = {
   dsn?: SentryOptions['dsn'];
   allowedCookies?: string[] | RegExp;
   allowedHeaders?: string[] | RegExp;


### PR DESCRIPTION
For my own selfish reasons, I would love for OtherOptions to be exported. I'm already handling passing the request, env and ctx but I still want to allow options for dsn, tags, etc. 

This PR will allow me to do that.

Example usage of what I'm doing:
```js

setup({ dsn: 'https://project@ingest.sentry.io/1' }, handleRequest);

async function handleRequest(req: Request, env: Env): Promise<Response> {}

export default { fetch: sentryFetch }
```