### PR TITLE
v2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toucan-js",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "Cloudflare Workers client for Sentry",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,14 @@ import {
   Extras,
   Primitive,
 } from '@sentry/types';
-import { Options, OtherOptions, Event, Breadcrumb, Level, RewriteFrames } from './types';
+import {
+  Options,
+  OtherOptions,
+  Event,
+  Breadcrumb,
+  Level,
+  RewriteFrames,
+} from './types';
 import { API } from '@sentry/core';
 import {
   isError,


### PR DESCRIPTION
## v2.7.0

- Tweaks reportException to recursively handle nested Errors it finds in the cause property. (@olizilla  in #104)
- Export `OtherOptions` type. (@WalshyDev in #99)
