### PR TITLE
Update to Sentry v8 SDKs

### DIFF
--- a/packages/toucan-js/package.json
+++ b/packages/toucan-js/package.json
@@ -29,9 +29,9 @@
     "serverless"
   ],
   "dependencies": {
-    "@sentry/core": "8.3.0",
-    "@sentry/utils": "8.3.0",
-    "@sentry/types": "8.3.0"
+    "@sentry/core": "8.9.2",
+    "@sentry/utils": "8.9.2",
+    "@sentry/types": "8.9.2"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "25.0.3",

--- a/packages/toucan-js/package.json
+++ b/packages/toucan-js/package.json
@@ -29,9 +29,9 @@
     "serverless"
   ],
   "dependencies": {
-    "@sentry/core": "8.0.0-rc.2",
-    "@sentry/utils": "8.0.0-rc.2",
-    "@sentry/types": "8.0.0-rc.2"
+    "@sentry/core": "8.0.0",
+    "@sentry/utils": "8.0.0",
+    "@sentry/types": "8.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "25.0.3",

--- a/packages/toucan-js/package.json
+++ b/packages/toucan-js/package.json
@@ -29,9 +29,9 @@
     "serverless"
   ],
   "dependencies": {
-    "@sentry/core": "8.0.0",
-    "@sentry/utils": "8.0.0",
-    "@sentry/types": "8.0.0"
+    "@sentry/core": "8.3.0",
+    "@sentry/utils": "8.3.0",
+    "@sentry/types": "8.3.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "25.0.3",

--- a/packages/toucan-js/package.json
+++ b/packages/toucan-js/package.json
@@ -29,10 +29,9 @@
     "serverless"
   ],
   "dependencies": {
-    "@sentry/core": "7.112.2",
-    "@sentry/utils": "7.112.2",
-    "@sentry/types": "7.112.2",
-    "@sentry/integrations": "7.112.2"
+    "@sentry/core": "8.0.0-rc.2",
+    "@sentry/utils": "8.0.0-rc.2",
+    "@sentry/types": "8.0.0-rc.2"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "25.0.3",

--- a/packages/toucan-js/src/client.ts
+++ b/packages/toucan-js/src/client.ts
@@ -13,11 +13,13 @@ import { setOnOptional } from './utils';
  */
 export class ToucanClient extends ServerRuntimeClient<ToucanClientOptions> {
   /**
-   * Some functions need to access the Hub (Toucan instance) this client is bound to,
+   * Some functions need to access the scope (Toucan instance) this client is bound to,
    * but calling 'getCurrentHub()' is unsafe because it uses globals.
    * So we store a reference to the Hub after binding to it and provide it to methods that need it.
    */
   #sdk: Toucan | null = null;
+
+  #integrationsInitialized: boolean = false;
 
   /**
    * Creates a new Toucan SDK instance.
@@ -43,12 +45,12 @@ export class ToucanClient extends ServerRuntimeClient<ToucanClientOptions> {
    * By default, integrations are stored in a global. We want to store them in a local instance because they may have contextual data, such as event request.
    */
   public setupIntegrations(): void {
-    if (this._isEnabled() && !this._integrationsInitialized && this.#sdk) {
+    if (this._isEnabled() && !this.#integrationsInitialized && this.#sdk) {
       this._integrations = setupIntegrations(
         this._options.integrations,
         this.#sdk,
       );
-      this._integrationsInitialized = true;
+      this.#integrationsInitialized = true;
     }
   }
 

--- a/packages/toucan-js/src/eventBuilder.ts
+++ b/packages/toucan-js/src/eventBuilder.ts
@@ -98,12 +98,10 @@ export function eventFromUnknownInput(
 
       const client = sdk?.getClient();
       const normalizeDepth = client && client.getOptions().normalizeDepth;
-      sdk?.configureScope((scope) => {
-        scope.setExtra(
-          '__serialized__',
-          normalizeToSize(exception, normalizeDepth),
-        );
-      });
+      sdk?.setExtra(
+        '__serialized__',
+        normalizeToSize(exception, normalizeDepth),
+      );
 
       ex = (hint && hint.syntheticException) || new Error(message);
       ex.message = message;

--- a/packages/toucan-js/src/index.ts
+++ b/packages/toucan-js/src/index.ts
@@ -1,11 +1,10 @@
 export {
-  LinkedErrors,
-  RequestData,
-  Dedupe,
-  ExtraErrorData,
-  RewriteFrames,
-  SessionTiming,
-  Transaction,
+  linkedErrorsIntegration,
+  requestDataIntegration,
+  dedupeIntegration,
+  extraErrorDataIntegration,
+  rewriteFramesIntegration,
+  sessionTimingIntegration,
 } from './integrations';
 export type { LinkedErrorsOptions, RequestDataOptions } from './integrations';
 export { Toucan } from './sdk';

--- a/packages/toucan-js/src/integration.ts
+++ b/packages/toucan-js/src/integration.ts
@@ -1,5 +1,5 @@
 import { IntegrationIndex } from '@sentry/core/types/integration';
-import type { EventProcessor, Integration } from '@sentry/types';
+import type { EventHint, Event, Integration } from '@sentry/types';
 import type { Toucan } from './sdk';
 
 /**
@@ -16,12 +16,41 @@ export function setupIntegrations(
   integrations.forEach((integration) => {
     integrationIndex[integration.name] = integration;
 
-    integration.setupOnce(
-      (callback: EventProcessor): void => {
-        sdk.getScope()?.addEventProcessor(callback);
-      },
-      () => sdk,
-    );
+    // `setupOnce` is only called the first time
+    if (typeof integration.setupOnce === 'function') {
+      integration.setupOnce();
+    }
+
+    const client = sdk.getClient();
+
+    if (!client) {
+      return;
+    }
+
+    // `setup` is run for each client
+    if (typeof integration.setup === 'function') {
+      integration.setup(client);
+    }
+
+    if (typeof integration.preprocessEvent === 'function') {
+      const callback = integration.preprocessEvent.bind(integration);
+      client.on('preprocessEvent', (event, hint) =>
+        callback(event, hint, client),
+      );
+    }
+
+    if (typeof integration.processEvent === 'function') {
+      const callback = integration.processEvent.bind(integration);
+
+      const processor = Object.assign(
+        (event: Event, hint: EventHint) => callback(event, hint, client),
+        {
+          id: integration.name,
+        },
+      );
+
+      client.addEventProcessor(processor);
+    }
   });
 
   return integrationIndex;

--- a/packages/toucan-js/src/integrations/index.ts
+++ b/packages/toucan-js/src/integrations/index.ts
@@ -1,9 +1,8 @@
 export * from './linkedErrors';
 export * from './requestData';
 export {
-  Dedupe,
-  ExtraErrorData,
-  RewriteFrames,
-  SessionTiming,
-  Transaction,
-} from '@sentry/integrations';
+  dedupeIntegration,
+  extraErrorDataIntegration,
+  rewriteFramesIntegration,
+  sessionTimingIntegration,
+} from '@sentry/core';

--- a/packages/toucan-js/src/sdk.ts
+++ b/packages/toucan-js/src/sdk.ts
@@ -1,54 +1,63 @@
-import { getIntegrationsToSetup, Hub, Scope } from '@sentry/core';
+import { Scope, getIntegrationsToSetup } from '@sentry/core';
 import { stackParserFromStackParserOptions } from '@sentry/utils';
 import { ToucanClient } from './client';
-import { LinkedErrors, RequestData } from './integrations';
+import {
+  linkedErrorsIntegration,
+  requestDataIntegration,
+} from './integrations';
 import { defaultStackParser } from './stacktrace';
 import { makeFetchTransport } from './transports';
 import type { Options } from './types';
 import { getSentryRelease } from './utils';
-import { CheckIn, MonitorConfig } from '@sentry/types';
+import type { Breadcrumb, CheckIn, MonitorConfig } from '@sentry/types';
 
 /**
  * The Cloudflare Workers SDK.
  */
-export class Toucan extends Hub {
-  constructor(options: Options) {
-    options.defaultIntegrations =
-      options.defaultIntegrations === false
-        ? []
-        : [
-            ...(Array.isArray(options.defaultIntegrations)
-              ? options.defaultIntegrations
-              : [
-                  new RequestData(options.requestDataOptions),
-                  new LinkedErrors(),
-                ]),
-          ];
+export class Toucan extends Scope {
+  constructor(options: Options | ToucanClient) {
+    super();
 
-    if (options.release === undefined) {
-      const detectedRelease = getSentryRelease();
-      if (detectedRelease !== undefined) {
-        options.release = detectedRelease;
+    if (options instanceof ToucanClient) {
+      this.setClient(options);
+      options.setSdk(this);
+    } else {
+      options.defaultIntegrations =
+        options.defaultIntegrations === false
+          ? []
+          : [
+              ...(Array.isArray(options.defaultIntegrations)
+                ? options.defaultIntegrations
+                : [
+                    requestDataIntegration(options.requestDataOptions),
+                    linkedErrorsIntegration(),
+                  ]),
+            ];
+
+      if (options.release === undefined) {
+        const detectedRelease = getSentryRelease();
+        if (detectedRelease !== undefined) {
+          options.release = detectedRelease;
+        }
       }
+
+      const client = new ToucanClient({
+        ...options,
+        transport: makeFetchTransport,
+        integrations: getIntegrationsToSetup(options),
+        stackParser: stackParserFromStackParserOptions(
+          options.stackParser || defaultStackParser,
+        ),
+        transportOptions: {
+          ...options.transportOptions,
+          context: options.context,
+        },
+      });
+
+      this.setClient(client);
+      client.setSdk(this);
+      client.setupIntegrations();
     }
-
-    const client = new ToucanClient({
-      ...options,
-      transport: makeFetchTransport,
-      integrations: getIntegrationsToSetup(options),
-      stackParser: stackParserFromStackParserOptions(
-        options.stackParser || defaultStackParser,
-      ),
-      transportOptions: {
-        ...options.transportOptions,
-        context: options.context,
-      },
-    });
-
-    super(client);
-
-    client.setSdk(this);
-    client.setupIntegrations();
   }
 
   /**
@@ -90,5 +99,41 @@ export class Toucan extends Hub {
 
     const client = this.getClient<ToucanClient>() as ToucanClient;
     return client.captureCheckIn(checkIn, monitorConfig, scope);
+  }
+
+  /**
+   * Add a breadcrumb to the current scope.
+   */
+  addBreadcrumb(breadcrumb: Breadcrumb, maxBreadcrumbs: number = 100): this {
+    const client = this.getClient<ToucanClient>() as ToucanClient;
+    const max = client.getOptions().maxBreadcrumbs || maxBreadcrumbs;
+
+    return super.addBreadcrumb(breadcrumb, max);
+  }
+
+  /**
+   * Creates a new scope with and executes the given operation within.
+   * The scope is automatically removed once the operation
+   * finishes or throws.
+   */
+  withScope<T>(callback: (scope: Toucan) => T): T {
+    // Clone this scope
+    const toucan = new Toucan(this.getClient<ToucanClient>() as ToucanClient);
+    // And copy all the scope data
+    toucan._breadcrumbs = [...this._breadcrumbs];
+    toucan._tags = { ...this._tags };
+    toucan._extra = { ...this._extra };
+    toucan._contexts = { ...this._contexts };
+    toucan._user = this._user;
+    toucan._level = this._level;
+    toucan._session = this._session;
+    toucan._transactionName = this._transactionName;
+    toucan._fingerprint = this._fingerprint;
+    toucan._eventProcessors = [...this._eventProcessors];
+    toucan._requestSession = this._requestSession;
+    toucan._attachments = [...this._attachments];
+    toucan._sdkProcessingMetadata = { ...this._sdkProcessingMetadata };
+    toucan._propagationContext = { ...this._propagationContext };
+    return callback(toucan);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1601,14 +1601,6 @@
     proxy-from-env "^1.1.0"
     which "^2.0.2"
 
-"@sentry/core@7.112.2":
-  version "7.112.2"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.112.2.tgz#d2e6d2acb6947fcb384298a3bd2b0c8183533dd8"
-  integrity sha512-gHPCcJobbMkk0VR18J65WYQTt3ED4qC6X9lHKp27Ddt63E+MDGkG6lvYBU1LS8cV7CdyBGC1XXDCfor61GvLsA==
-  dependencies:
-    "@sentry/types" "7.112.2"
-    "@sentry/utils" "7.112.2"
-
 "@sentry/core@7.23.0":
   version "7.23.0"
   resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.23.0.tgz#d320b2b6e5620b41f345bc01d69b547cdf28f78d"
@@ -1618,22 +1610,20 @@
     "@sentry/utils" "7.23.0"
     tslib "^1.9.3"
 
+"@sentry/core@8.0.0-rc.2":
+  version "8.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-8.0.0-rc.2.tgz#839f447b263d69ec20264533e905a6db06835bc6"
+  integrity sha512-GNG0VYFS5EiJJHbJ9nRc3CPb2EU2eAtkDlWlQtkKu/jvHE7NG6ik8qk841Yw3ki7KWN05IVMD5FhtxDHjEYXkw==
+  dependencies:
+    "@sentry/types" "8.0.0-rc.2"
+    "@sentry/utils" "8.0.0-rc.2"
+
 "@sentry/esbuild-plugin@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@sentry/esbuild-plugin/-/esbuild-plugin-0.2.3.tgz#0e5633d114c185b1a5aa4357ba4c746d732547cc"
   integrity sha512-NtdxoBUlACenAJBeyuFzHlI9Irjkh2j6MO+80iVp6tKJ2MAQcNHc26lkZ8ABjvOvi0SC2vzlarPV2vRPW4B7Vw==
   dependencies:
     "@sentry/bundler-plugin-core" "0.2.3"
-
-"@sentry/integrations@7.112.2":
-  version "7.112.2"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.112.2.tgz#2aad01719b1e4a1326f42db78f77fcf1e58d4c63"
-  integrity sha512-ioC2yyU6DqtLkdmWnm87oNvdn2+9oKctJeA4t+jkS6JaJ10DcezjCwiLscX4rhB9aWJV3IWF7Op0O6K3w0t2Hg==
-  dependencies:
-    "@sentry/core" "7.112.2"
-    "@sentry/types" "7.112.2"
-    "@sentry/utils" "7.112.2"
-    localforage "^1.8.1"
 
 "@sentry/node@^7.19.0":
   version "7.23.0"
@@ -1665,22 +1655,15 @@
     "@sentry/utils" "7.23.0"
     tslib "^1.9.3"
 
-"@sentry/types@7.112.2":
-  version "7.112.2"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.112.2.tgz#71ff27c668309ccd8d17b7793e044e46f81eca1b"
-  integrity sha512-kCMLt7yhY5OkWE9MeowlTNmox9pqDxcpvqguMo4BDNZM5+v9SEb1AauAdR78E1a1V8TyCzjBD7JDfXWhvpYBcQ==
-
 "@sentry/types@7.23.0":
   version "7.23.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.23.0.tgz#5d2ce94d81d7c1fad702645306f3c0932708cad5"
   integrity sha512-fZ5XfVRswVZhKoCutQ27UpIHP16tvyc6ws+xq+njHv8Jg8gFBCoOxlJxuFhegD2xxylAn1aiSHNAErFWdajbpA==
 
-"@sentry/utils@7.112.2":
-  version "7.112.2"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.112.2.tgz#223f9feee5860459792a43904db4bf38fba73ed3"
-  integrity sha512-OjLh0hx0t1EcL4ZIjf+4svlmmP+tHUDGcr5qpFWH78tjmkPW4+cqPuZCZfHSuWcDdeiaXi8TnYoVRqDcJKK/eQ==
-  dependencies:
-    "@sentry/types" "7.112.2"
+"@sentry/types@8.0.0-rc.2":
+  version "8.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-8.0.0-rc.2.tgz#e2ec9e29f1b0b0af2ce20b6ba6be45b606955707"
+  integrity sha512-A52WamMnmJnRFrw6S9tmp52eGSdRWlTTvbXMF5mBE/8RCwknAFuPcXetFpKtU/ixqK+oeGtXLrJOuSJhWDvnVg==
 
 "@sentry/utils@7.23.0":
   version "7.23.0"
@@ -1689,6 +1672,13 @@
   dependencies:
     "@sentry/types" "7.23.0"
     tslib "^1.9.3"
+
+"@sentry/utils@8.0.0-rc.2":
+  version "8.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-8.0.0-rc.2.tgz#d915ed23a71d1a5b627f209380b1595eccbf81da"
+  integrity sha512-Ev0nhHVfMb82gtUHuqfbJNaeQZG/wzzO0+hiUFOXuGdJEFItYpv/z2TlfXEFQ8NX8nD0gWSFMlUCF8ySi0IMXA==
+  dependencies:
+    "@sentry/types" "8.0.0-rc.2"
 
 "@sentry/vite-plugin@^0.2.3":
   version "0.2.3"
@@ -4091,11 +4081,6 @@ ignore@^5.2.0, ignore@^5.2.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
-immediate@~3.0.5:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
-  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
-
 import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -4976,13 +4961,6 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-lie@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
-  integrity sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==
-  dependencies:
-    immediate "~3.0.5"
-
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
@@ -5002,13 +4980,6 @@ loader-runner@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.3.0.tgz#c1b4a163b99f614830353b16755e7149ac2314e1"
   integrity sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==
-
-localforage@^1.8.1:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.10.0.tgz#5c465dc5f62b2807c3a84c0c6a1b1b3212781dd4"
-  integrity sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==
-  dependencies:
-    lie "3.1.1"
 
 locate-path@^5.0.0:
   version "5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1610,13 +1610,13 @@
     "@sentry/utils" "7.23.0"
     tslib "^1.9.3"
 
-"@sentry/core@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-8.0.0.tgz#fd5f94c9ef72ce386ae37de852f156106ea807d5"
-  integrity sha512-PgOqQPdlIbiLFOo0F6IBzMbvusiEQ86+yXd76pIsuqQ2tj+iFL5gdYOckF/FKVpAwhfzIx64GKin2C+535c1qQ==
+"@sentry/core@8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-8.3.0.tgz#beb91aeceb6be2a623773d7cabd6f8396c3f5926"
+  integrity sha512-X7r0WujE7DILtgA5zt4hmHMBTF3xbjJB7Dgrw1Hv5C7WG5qkNqhDPpnRX7WswtHcLSgVPY2GRTQ5Iid7i33zEQ==
   dependencies:
-    "@sentry/types" "8.0.0"
-    "@sentry/utils" "8.0.0"
+    "@sentry/types" "8.3.0"
+    "@sentry/utils" "8.3.0"
 
 "@sentry/esbuild-plugin@^0.2.3":
   version "0.2.3"
@@ -1660,10 +1660,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.23.0.tgz#5d2ce94d81d7c1fad702645306f3c0932708cad5"
   integrity sha512-fZ5XfVRswVZhKoCutQ27UpIHP16tvyc6ws+xq+njHv8Jg8gFBCoOxlJxuFhegD2xxylAn1aiSHNAErFWdajbpA==
 
-"@sentry/types@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-8.0.0.tgz#5047dcbcff6a38699e4490acd941baffafb72f45"
-  integrity sha512-Dtd8dtFEq1XtdAntkguYHaL4tokzm4Aq5t0HP6Vl1P+MPImokDE1UcpKglkh0Z5aym/vF6e0qW9/CM7lAI5R/A==
+"@sentry/types@8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-8.3.0.tgz#c5df6d5702a7e2483cf87e82df0cd82297c9c3d7"
+  integrity sha512-DbwRTdx5xn8c2EhElD1UneDbcfqz220INPJYiATGJ9pR+cV5kGohyxI6lJxebPdPhPLEFQqYdLXGA6Cjm/uC6A==
 
 "@sentry/utils@7.23.0":
   version "7.23.0"
@@ -1673,12 +1673,12 @@
     "@sentry/types" "7.23.0"
     tslib "^1.9.3"
 
-"@sentry/utils@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-8.0.0.tgz#24b2f3f24cf521c0180e4335da63a4c6e51fa7dd"
-  integrity sha512-oZex/dRKfkWHoK99W7QDQtr26IZrAD9EDd2+pwLmkFclApxVDGLLKNkmcbfj4LX1zMROxKWww/GTE7eo08tEKg==
+"@sentry/utils@8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-8.3.0.tgz#c06f3a3ff40d8f8d1d8901a50d676c748575e66d"
+  integrity sha512-WFaUZy0OWsF6Mrjenxj4N8zGzA6+pdH2lCV60/IB+V5PvGPgl40MUyjN6aLA/E9BRpqwLNQRMroZjln+J/3aiA==
   dependencies:
-    "@sentry/types" "8.0.0"
+    "@sentry/types" "8.3.0"
 
 "@sentry/vite-plugin@^0.2.3":
   version "0.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1610,13 +1610,13 @@
     "@sentry/utils" "7.23.0"
     tslib "^1.9.3"
 
-"@sentry/core@8.0.0-rc.2":
-  version "8.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-8.0.0-rc.2.tgz#839f447b263d69ec20264533e905a6db06835bc6"
-  integrity sha512-GNG0VYFS5EiJJHbJ9nRc3CPb2EU2eAtkDlWlQtkKu/jvHE7NG6ik8qk841Yw3ki7KWN05IVMD5FhtxDHjEYXkw==
+"@sentry/core@8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-8.0.0.tgz#fd5f94c9ef72ce386ae37de852f156106ea807d5"
+  integrity sha512-PgOqQPdlIbiLFOo0F6IBzMbvusiEQ86+yXd76pIsuqQ2tj+iFL5gdYOckF/FKVpAwhfzIx64GKin2C+535c1qQ==
   dependencies:
-    "@sentry/types" "8.0.0-rc.2"
-    "@sentry/utils" "8.0.0-rc.2"
+    "@sentry/types" "8.0.0"
+    "@sentry/utils" "8.0.0"
 
 "@sentry/esbuild-plugin@^0.2.3":
   version "0.2.3"
@@ -1660,10 +1660,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.23.0.tgz#5d2ce94d81d7c1fad702645306f3c0932708cad5"
   integrity sha512-fZ5XfVRswVZhKoCutQ27UpIHP16tvyc6ws+xq+njHv8Jg8gFBCoOxlJxuFhegD2xxylAn1aiSHNAErFWdajbpA==
 
-"@sentry/types@8.0.0-rc.2":
-  version "8.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-8.0.0-rc.2.tgz#e2ec9e29f1b0b0af2ce20b6ba6be45b606955707"
-  integrity sha512-A52WamMnmJnRFrw6S9tmp52eGSdRWlTTvbXMF5mBE/8RCwknAFuPcXetFpKtU/ixqK+oeGtXLrJOuSJhWDvnVg==
+"@sentry/types@8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-8.0.0.tgz#5047dcbcff6a38699e4490acd941baffafb72f45"
+  integrity sha512-Dtd8dtFEq1XtdAntkguYHaL4tokzm4Aq5t0HP6Vl1P+MPImokDE1UcpKglkh0Z5aym/vF6e0qW9/CM7lAI5R/A==
 
 "@sentry/utils@7.23.0":
   version "7.23.0"
@@ -1673,12 +1673,12 @@
     "@sentry/types" "7.23.0"
     tslib "^1.9.3"
 
-"@sentry/utils@8.0.0-rc.2":
-  version "8.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-8.0.0-rc.2.tgz#d915ed23a71d1a5b627f209380b1595eccbf81da"
-  integrity sha512-Ev0nhHVfMb82gtUHuqfbJNaeQZG/wzzO0+hiUFOXuGdJEFItYpv/z2TlfXEFQ8NX8nD0gWSFMlUCF8ySi0IMXA==
+"@sentry/utils@8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-8.0.0.tgz#24b2f3f24cf521c0180e4335da63a4c6e51fa7dd"
+  integrity sha512-oZex/dRKfkWHoK99W7QDQtr26IZrAD9EDd2+pwLmkFclApxVDGLLKNkmcbfj4LX1zMROxKWww/GTE7eo08tEKg==
   dependencies:
-    "@sentry/types" "8.0.0-rc.2"
+    "@sentry/types" "8.0.0"
 
 "@sentry/vite-plugin@^0.2.3":
   version "0.2.3"


### PR DESCRIPTION
Closes #232 and closes #221

This PR updates the Sentry SDKs to v8.0.0-rc.2 which involves some breaking changes:
- Converts integrations to the newer functional API and naming convention
  - Removes the `Transaction` integration since it's no longer required
- Sentry have removed the hub concept entirely so `Toucan` now extends `Scope`
- To isolate scope changes, `withScope` now clones the `Toucan` class which is passed as the callback parameter
  - Sentry's `withScope` handling is a lot more complex because it has to consider isolation
  - I changed the `withScope` tests to use `toStrictEqual` on `extra` because they were passing when they should have been failing

The main thing I'm not that happy with is that `Toucan` holds a reference to `ToucanClient` (due to Sentry's own client ref in `Scope`) and `ToucanClient` holds a reference to `Toucan` (`#sdk`) . This circular reference is unfortunate and there may be a way to improve this but I haven't put much thought into it yet and it might not be a massive issue 🙂

It should be relatively easy to get Sentry Metrics working too but they do use a global to store a metrics aggregator per client (`WeakMap<Client, MetricsAggregatorInterface>`).  I can't imagine this would be too much of an issue since it stores a unique metrics aggregator per client and `toucan-js` has a unique client per request.