### PR TITLE
v4.0.0

### DIFF
--- a/.changeset/silent-swans-rescue.md
+++ b/.changeset/silent-swans-rescue.md
@@ -1,0 +1,18 @@
+---
+'toucan-js': major
+---
+
+This release upgrades the underlying Sentry SDKs to v8.
+
+- Toucan now extends [ScopeClass](https://github.com/getsentry/sentry-javascript/blob/master/packages/core/src/scope.ts) instead of Hub.
+- Class-based integrations have been removed in Sentry v8. Toucan adapts to this change by renaming:
+  - `Dedupe` integration to `dedupeIntegration`
+  - `ExtraErrorData` integration to `extraErrorDataIntegration`
+  - `RewriteFrames` integration to `rewriteFramesIntegration`
+  - `SessionTiming` integration to `sessionTimingIntegration`
+  - `LinkedErrors` integration to `linkedErrorsIntegration`
+  - `RequestData` integration to `requestDataIntegration`
+- Additionally, `Transaction` integration is no longer provided.
+- Toucan instance can now be deeply copied using `Toucan.clone()`.
+
+Refer to [Sentry v8 release notes](https://github.com/getsentry/sentry-javascript/releases/tag/8.0.0) and [Sentry v7->v8](https://github.com/getsentry/sentry-javascript/blob/8.0.0/MIGRATION.md) for additional context.

--- a/packages/toucan-js/README.md
+++ b/packages/toucan-js/README.md
@@ -16,7 +16,7 @@
 
 ## Features
 
-This SDK provides all options and methods of [Hub](https://github.com/getsentry/sentry-javascript/blob/master/packages/core/src/hub.ts) and additionally:
+This SDK provides all options and methods of [ScopeClass](https://github.com/getsentry/sentry-javascript/blob/master/packages/core/src/scope.ts) and additionally:
 
 ### Additional constructor options
 
@@ -44,30 +44,27 @@ On top of base `transportOptions` you can pass additional configuration:
 
 ## Integrations
 
-You can use custom integrations to enhance `toucan-js` as you would any other Sentry SDK. Some integrations are provided in [@sentry/integrations](https://github.com/getsentry/sentry-javascript/tree/master/packages/integrations) package, and you can also write your own! To ensure an integration will work properly in `toucan-js`, it must:
+You can use custom integrations to enhance `toucan-js` as you would any other Sentry SDK. Some integrations are provided in various [Sentry packages](https://github.com/getsentry/sentry-javascript/tree/develop/packages), and you can also write your own! To ensure an integration will work properly in `toucan-js`, it must:
 
-- not use global `getCurrentHub` from `@sentry/core`.
 - not enhance or wrap global runtime methods (such as `console.log`).
 - not use runtime APIs that aren't available in Cloudflare Workers (NodeJS runtime functions, `window` object, etc...).
 
-Supported integrations from [@sentry/integrations](https://github.com/getsentry/sentry-javascript/tree/master/packages/integrations) are re-exported from `toucan-js`:
+Supported integrations from [@sentry/core](https://github.com/getsentry/sentry-javascript/tree/develop/packages/core) are re-exported from `toucan-js`:
 
-- [Dedupe](https://github.com/getsentry/sentry-javascript/blob/master/packages/integrations/src/dedupe.ts)
-- [ExtraErrorData](https://github.com/getsentry/sentry-javascript/blob/master/packages/integrations/src/extraerrordata.ts)
-- [RewriteFrames](https://github.com/getsentry/sentry-javascript/blob/master/packages/integrations/src/rewriteframes.ts)
-- [SessionTiming](https://github.com/getsentry/sentry-javascript/blob/master/packages/integrations/src/sessiontiming.ts)
-- [Transaction](https://github.com/getsentry/sentry-javascript/blob/master/packages/integrations/src/transaction.ts)
+- [dedupeIntegration](https://github.com/getsentry/sentry-javascript/blob/master/packages/integrations/src/dedupe.ts)
+- [extraErrorDataIntegration](https://github.com/getsentry/sentry-javascript/blob/master/packages/integrations/src/extraerrordata.ts)
+- [rewriteFramesIntegration](https://github.com/getsentry/sentry-javascript/blob/master/packages/integrations/src/rewriteframes.ts)
+- [sessionTimingIntegration](https://github.com/getsentry/sentry-javascript/blob/master/packages/integrations/src/sessiontiming.ts)
 
 `toucan-js` also provides 2 integrations that are enabled by default, but are provided if you need to reconfigure them:
 
-- [LinkedErrors](src/integrations/linkedErrors.ts)
-- [RequestData](src/integrations/requestData.ts)
+- [linkedErrorsIntegration](src/integrations/linkedErrors.ts)
+- [requestDataIntegration](src/integrations/requestData.ts)
 
 ### Custom integration example:
 
 ```ts
-import { Toucan } from 'toucan-js';
-import { RewriteFrames } from '@sentry/integrations';
+import { Toucan, rewriteFramesIntegration } from 'toucan-js';
 
 type Env = {
   SENTRY_DSN: string;
@@ -79,7 +76,7 @@ export default {
       dsn: env.SENTRY_DSN,
       context,
       request,
-      integrations: [new RewriteFrames({ root: '/' })],
+      integrations: [rewriteFramesIntegration({ root: '/' })],
     });
 
     ...

--- a/yarn.lock
+++ b/yarn.lock
@@ -1610,13 +1610,13 @@
     "@sentry/utils" "7.23.0"
     tslib "^1.9.3"
 
-"@sentry/core@8.3.0":
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-8.3.0.tgz#beb91aeceb6be2a623773d7cabd6f8396c3f5926"
-  integrity sha512-X7r0WujE7DILtgA5zt4hmHMBTF3xbjJB7Dgrw1Hv5C7WG5qkNqhDPpnRX7WswtHcLSgVPY2GRTQ5Iid7i33zEQ==
+"@sentry/core@8.9.2":
+  version "8.9.2"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-8.9.2.tgz#af0f2ec25b88da5467cf327d2ffcd555323c30e6"
+  integrity sha512-ixm8NISFlPlEo3FjSaqmq4nnd13BRHoafwJ5MG+okCz6BKGZ1SexEggP42/QpGvDprUUHnfncG6WUMgcarr1zA==
   dependencies:
-    "@sentry/types" "8.3.0"
-    "@sentry/utils" "8.3.0"
+    "@sentry/types" "8.9.2"
+    "@sentry/utils" "8.9.2"
 
 "@sentry/esbuild-plugin@^0.2.3":
   version "0.2.3"
@@ -1660,10 +1660,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.23.0.tgz#5d2ce94d81d7c1fad702645306f3c0932708cad5"
   integrity sha512-fZ5XfVRswVZhKoCutQ27UpIHP16tvyc6ws+xq+njHv8Jg8gFBCoOxlJxuFhegD2xxylAn1aiSHNAErFWdajbpA==
 
-"@sentry/types@8.3.0":
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-8.3.0.tgz#c5df6d5702a7e2483cf87e82df0cd82297c9c3d7"
-  integrity sha512-DbwRTdx5xn8c2EhElD1UneDbcfqz220INPJYiATGJ9pR+cV5kGohyxI6lJxebPdPhPLEFQqYdLXGA6Cjm/uC6A==
+"@sentry/types@8.9.2":
+  version "8.9.2"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-8.9.2.tgz#d143383fc35552d9f153042cc6d56c5ee8ec2fa6"
+  integrity sha512-+LFOyQGl+zk5SZRGZD2MEURf7i5RHgP/mt3s85Rza+vz8M211WJ0YsjkIGUJFSY842nged5QLx4JysLaBlLymg==
 
 "@sentry/utils@7.23.0":
   version "7.23.0"
@@ -1673,12 +1673,12 @@
     "@sentry/types" "7.23.0"
     tslib "^1.9.3"
 
-"@sentry/utils@8.3.0":
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-8.3.0.tgz#c06f3a3ff40d8f8d1d8901a50d676c748575e66d"
-  integrity sha512-WFaUZy0OWsF6Mrjenxj4N8zGzA6+pdH2lCV60/IB+V5PvGPgl40MUyjN6aLA/E9BRpqwLNQRMroZjln+J/3aiA==
+"@sentry/utils@8.9.2":
+  version "8.9.2"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-8.9.2.tgz#58b003d9c1302f61192e7c99ea42bf1cd5cad7f7"
+  integrity sha512-A4srR9mEBFdVXwSEKjQ94msUbVkMr8JeFiEj9ouOFORw/Y/ux/WV2bWVD/ZI9wq0TcTNK8L1wBgU8UMS5lIq3A==
   dependencies:
-    "@sentry/types" "8.3.0"
+    "@sentry/types" "8.9.2"
 
 "@sentry/vite-plugin@^0.2.3":
   version "0.2.3"


### PR DESCRIPTION
This PR is a follow-up to https://github.com/robertcepa/toucan-js/pull/234:
- `withScope`: new `ToucanClient` is created with new Scope, instead of linking to old one. This allows us to remove ` ToucanClient` as an option in constructor as well.
- Overrides `clone()` method on extended `Scope` to work properly.
- Updates documentation
- Adds changeset in preparation for the release