### PR TITLE
feat: Add zodErrorsIntegration

### DIFF
--- a/.changeset/gentle-turkeys-flow.md
+++ b/.changeset/gentle-turkeys-flow.md
@@ -1,0 +1,7 @@
+---
+'toucan-js': minor
+---
+
+feat: Add zodErrorsIntegration
+
+This integration improves the format of errors recorded to Sentry when using Zod

--- a/packages/toucan-js/README.md
+++ b/packages/toucan-js/README.md
@@ -60,6 +60,7 @@ Supported integrations from [@sentry/core](https://github.com/getsentry/sentry-j
 
 - [linkedErrorsIntegration](src/integrations/linkedErrors.ts)
 - [requestDataIntegration](src/integrations/requestData.ts)
+- [zodErrorsIntegration](src/integrations/zod/zoderrors.ts)
 
 ### Custom integration example:
 

--- a/packages/toucan-js/src/integrations/index.ts
+++ b/packages/toucan-js/src/integrations/index.ts
@@ -1,5 +1,6 @@
 export * from './linkedErrors';
 export * from './requestData';
+export { zodErrorsIntegration } from './zod/zoderrors';
 export {
   dedupeIntegration,
   extraErrorDataIntegration,

--- a/packages/toucan-js/src/integrations/zod/integration.ts
+++ b/packages/toucan-js/src/integrations/zod/integration.ts
@@ -1,0 +1,13 @@
+import type { Integration, IntegrationFn } from '@sentry/types';
+
+/**
+ * Define an integration function that can be used to create an integration instance.
+ * Note that this by design hides the implementation details of the integration, as they are considered internal.
+ *
+ * Inlined from https://github.com/getsentry/sentry-javascript/blob/develop/packages/core/src/integration.ts#L165
+ */
+export function defineIntegration<Fn extends IntegrationFn>(
+  fn: Fn,
+): (...args: Parameters<Fn>) => Integration {
+  return fn;
+}

--- a/packages/toucan-js/src/integrations/zod/zoderrors.spec.ts
+++ b/packages/toucan-js/src/integrations/zod/zoderrors.spec.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it, test } from '@jest/globals';
+import { z } from 'zod';
+
+import {
+  flattenIssue,
+  flattenIssuePath,
+  formatIssueMessage,
+} from './zoderrors';
+
+describe('flattenIssue()', () => {
+  it('flattens path field', () => {
+    const zodError = z
+      .object({
+        foo: z.string().min(1),
+        nested: z.object({
+          bar: z.literal('baz'),
+        }),
+      })
+      .safeParse({
+        foo: '',
+        nested: {
+          bar: 'not-baz',
+        },
+      }).error;
+    if (zodError === undefined) {
+      throw new Error('zodError is undefined');
+    }
+
+    // Original zod error
+    expect(zodError.issues).toMatchInlineSnapshot(`
+			[
+			  {
+			    "code": "too_small",
+			    "exact": false,
+			    "inclusive": true,
+			    "message": "String must contain at least 1 character(s)",
+			    "minimum": 1,
+			    "path": [
+			      "foo",
+			    ],
+			    "type": "string",
+			  },
+			  {
+			    "code": "invalid_literal",
+			    "expected": "baz",
+			    "message": "Invalid literal value, expected "baz"",
+			    "path": [
+			      "nested",
+			      "bar",
+			    ],
+			    "received": "not-baz",
+			  },
+			]
+		`);
+
+    const issues = zodError.issues;
+    expect(issues.length).toBe(2);
+
+    // Format it for use in Sentry
+    expect(issues.map(flattenIssue)).toMatchInlineSnapshot(`
+			[
+			  {
+			    "code": "too_small",
+			    "exact": false,
+			    "inclusive": true,
+			    "keys": undefined,
+			    "message": "String must contain at least 1 character(s)",
+			    "minimum": 1,
+			    "path": "foo",
+			    "type": "string",
+			    "unionErrors": undefined,
+			  },
+			  {
+			    "code": "invalid_literal",
+			    "expected": "baz",
+			    "keys": undefined,
+			    "message": "Invalid literal value, expected "baz"",
+			    "path": "nested.bar",
+			    "received": "not-baz",
+			    "unionErrors": undefined,
+			  },
+			]
+		`);
+  });
+
+  it('flattens keys field to string', () => {
+    const zodError = z
+      .object({
+        foo: z.string().min(1),
+      })
+      .strict()
+      .safeParse({
+        foo: 'bar',
+        extra_key_abc: 'hello',
+        extra_key_def: 'world',
+      }).error;
+    if (zodError === undefined) {
+      throw new Error('zodError is undefined');
+    }
+
+    // Original zod error
+    expect(zodError.issues).toMatchInlineSnapshot(`
+			[
+			  {
+			    "code": "unrecognized_keys",
+			    "keys": [
+			      "extra_key_abc",
+			      "extra_key_def",
+			    ],
+			    "message": "Unrecognized key(s) in object: 'extra_key_abc', 'extra_key_def'",
+			    "path": [],
+			  },
+			]
+		`);
+
+    const issues = zodError.issues;
+    expect(issues.length).toBe(1);
+
+    // Format it for use in Sentry
+    const formattedIssue = flattenIssue(issues[0]);
+
+    // keys is now a string rather than array.
+    // Note: path is an empty string because the issue is at the root.
+    // TODO: Maybe somehow make it clearer that this is at the root?
+    expect(formattedIssue).toMatchInlineSnapshot(`
+			{
+			  "code": "unrecognized_keys",
+			  "keys": "["extra_key_abc","extra_key_def"]",
+			  "message": "Unrecognized key(s) in object: 'extra_key_abc', 'extra_key_def'",
+			  "path": "",
+			  "unionErrors": undefined,
+			}
+		`);
+    expect(typeof formattedIssue.keys === 'string').toBe(true);
+  });
+});
+
+describe('flattenIssuePath()', () => {
+  it('returns single path', () => {
+    expect(flattenIssuePath(['foo'])).toBe('foo');
+  });
+
+  it('flattens nested string paths', () => {
+    expect(flattenIssuePath(['foo', 'bar'])).toBe('foo.bar');
+  });
+
+  it('uses placeholder for path index within array', () => {
+    expect(flattenIssuePath([0, 'foo', 1, 'bar'])).toBe(
+      '<array>.foo.<array>.bar',
+    );
+  });
+});
+
+describe('formatIssueMessage()', () => {
+  it('adds invalid keys to message', () => {
+    const zodError = z
+      .object({
+        foo: z.string().min(1),
+        nested: z.object({
+          bar: z.literal('baz'),
+        }),
+      })
+      .safeParse({
+        foo: '',
+        nested: {
+          bar: 'not-baz',
+        },
+      }).error;
+    if (zodError === undefined) {
+      throw new Error('zodError is undefined');
+    }
+
+    const message = formatIssueMessage(zodError);
+    expect(message).toMatchInlineSnapshot(
+      `"Failed to validate keys: foo, nested.bar"`,
+    );
+  });
+
+  describe('adds expected type if root variable is invalid', () => {
+    test('object', () => {
+      const zodError = z
+        .object({
+          foo: z.string().min(1),
+        })
+        .safeParse(123).error;
+      if (zodError === undefined) {
+        throw new Error('zodError is undefined');
+      }
+
+      // Original zod error
+      expect(zodError.issues).toMatchInlineSnapshot(`
+				[
+				  {
+				    "code": "invalid_type",
+				    "expected": "object",
+				    "message": "Expected object, received number",
+				    "path": [],
+				    "received": "number",
+				  },
+				]
+			`);
+
+      const message = formatIssueMessage(zodError);
+      expect(message).toMatchInlineSnapshot(`"Failed to validate object"`);
+    });
+
+    test('number', () => {
+      const zodError = z.number().safeParse('123').error;
+      if (zodError === undefined) {
+        throw new Error('zodError is undefined');
+      }
+
+      // Original zod error
+      expect(zodError.issues).toMatchInlineSnapshot(`
+				[
+				  {
+				    "code": "invalid_type",
+				    "expected": "number",
+				    "message": "Expected number, received string",
+				    "path": [],
+				    "received": "string",
+				  },
+				]
+			`);
+
+      const message = formatIssueMessage(zodError);
+      expect(message).toMatchInlineSnapshot(`"Failed to validate number"`);
+    });
+
+    test('string', () => {
+      const zodError = z.string().safeParse(123).error;
+      if (zodError === undefined) {
+        throw new Error('zodError is undefined');
+      }
+
+      // Original zod error
+      expect(zodError.issues).toMatchInlineSnapshot(`
+				[
+				  {
+				    "code": "invalid_type",
+				    "expected": "string",
+				    "message": "Expected string, received number",
+				    "path": [],
+				    "received": "number",
+				  },
+				]
+			`);
+
+      const message = formatIssueMessage(zodError);
+      expect(message).toMatchInlineSnapshot(`"Failed to validate string"`);
+    });
+
+    test('array', () => {
+      const zodError = z.string().array().safeParse('123').error;
+      if (zodError === undefined) {
+        throw new Error('zodError is undefined');
+      }
+
+      // Original zod error
+      expect(zodError.issues).toMatchInlineSnapshot(`
+				[
+				  {
+				    "code": "invalid_type",
+				    "expected": "array",
+				    "message": "Expected array, received string",
+				    "path": [],
+				    "received": "string",
+				  },
+				]
+			`);
+
+      const message = formatIssueMessage(zodError);
+      expect(message).toMatchInlineSnapshot(`"Failed to validate array"`);
+    });
+
+    test('wrong type in array', () => {
+      const zodError = z.string().array().safeParse([123]).error;
+      if (zodError === undefined) {
+        throw new Error('zodError is undefined');
+      }
+
+      // Original zod error
+      expect(zodError.issues).toMatchInlineSnapshot(`
+				[
+				  {
+				    "code": "invalid_type",
+				    "expected": "string",
+				    "message": "Expected string, received number",
+				    "path": [
+				      0,
+				    ],
+				    "received": "number",
+				  },
+				]
+			`);
+
+      const message = formatIssueMessage(zodError);
+      expect(message).toMatchInlineSnapshot(
+        `"Failed to validate keys: <array>"`,
+      );
+    });
+  });
+});

--- a/packages/toucan-js/src/integrations/zod/zoderrors.ts
+++ b/packages/toucan-js/src/integrations/zod/zoderrors.ts
@@ -1,0 +1,233 @@
+// Adapted from: https://github.com/getsentry/sentry-javascript/blob/develop/packages/core/src/integrations/zoderrors.ts
+
+import { isError, truncate } from '@sentry/utils';
+
+import { defineIntegration } from './integration';
+
+import type { Event, EventHint } from '@sentry/types';
+import type { ZodError, ZodIssue } from 'zod';
+
+const INTEGRATION_NAME = 'ZodErrors';
+const DEFAULT_LIMIT = 10;
+
+interface ZodErrorsOptions {
+  /**
+   * Limits the number of Zod errors inlined in each Sentry event.
+   *
+   * @default 10
+   */
+  limit?: number;
+  /**
+   * Optionally save full error info as an attachment in Sentry
+   */
+  saveAttachments?: boolean;
+}
+
+function originalExceptionIsZodError(
+  originalException: unknown,
+): originalException is ZodError {
+  return (
+    isError(originalException) &&
+    originalException.name === 'ZodError' &&
+    Array.isArray((originalException as ZodError).errors)
+  );
+}
+
+/**
+ * Simplified ZodIssue type definition
+ */
+type SimpleZodIssue = {
+  path: Array<string | number>;
+  message?: string;
+  expected?: unknown;
+  received?: unknown;
+  unionErrors?: unknown[];
+  keys?: unknown[];
+  invalid_literal?: unknown;
+};
+
+type SingleLevelZodIssue<T extends SimpleZodIssue> = {
+  [P in keyof T]: T[P] extends string | number | undefined
+    ? T[P]
+    : T[P] extends unknown[]
+    ? string | undefined
+    : unknown;
+};
+
+/**
+ * Formats child objects or arrays to a string
+ * that is preserved when sent to Sentry.
+ *
+ * Without this, we end up with something like this in Sentry:
+ *
+ * [
+ *  [Object],
+ *  [Object],
+ *  [Object],
+ *  [Object]
+ * ]
+ */
+export function flattenIssue(
+  issue: ZodIssue,
+): SingleLevelZodIssue<SimpleZodIssue> {
+  return {
+    ...issue,
+    path:
+      'path' in issue && Array.isArray(issue.path)
+        ? issue.path.join('.')
+        : undefined,
+    keys: 'keys' in issue ? JSON.stringify(issue.keys) : undefined,
+    unionErrors:
+      'unionErrors' in issue ? JSON.stringify(issue.unionErrors) : undefined,
+  };
+}
+
+/**
+ * Takes ZodError issue path array and returns a flattened version as a string.
+ * This makes it easier to display paths within a Sentry error message.
+ *
+ * Array indexes are normalized to reduce duplicate entries
+ *
+ * @param path ZodError issue path
+ * @returns flattened path
+ *
+ * @example
+ * flattenIssuePath([0, 'foo', 1, 'bar']) // -> '<array>.foo.<array>.bar'
+ */
+export function flattenIssuePath(path: Array<string | number>): string {
+  return path
+    .map((p) => {
+      if (typeof p === 'number') {
+        return '<array>';
+      } else {
+        return p;
+      }
+    })
+    .join('.');
+}
+
+/**
+ * Zod error message is a stringified version of ZodError.issues
+ * This doesn't display well in the Sentry UI. Replace it with something shorter.
+ */
+export function formatIssueMessage(zodError: ZodError): string {
+  const errorKeyMap = new Set<string | number | symbol>();
+  for (const iss of zodError.issues) {
+    const issuePath = flattenIssuePath(iss.path);
+    if (issuePath.length > 0) {
+      errorKeyMap.add(issuePath);
+    }
+  }
+
+  const errorKeys = Array.from(errorKeyMap);
+  if (errorKeys.length === 0) {
+    // If there are no keys, then we're likely validating the root
+    // variable rather than a key within an object. This attempts
+    // to extract what type it was that failed to validate.
+    // For example, z.string().parse(123) would return "string" here.
+    let rootExpectedType = 'variable';
+    if (zodError.issues.length > 0) {
+      const iss = zodError.issues[0];
+      if ('expected' in iss && typeof iss.expected === 'string') {
+        rootExpectedType = iss.expected;
+      }
+    }
+    return `Failed to validate ${rootExpectedType}`;
+  }
+  return `Failed to validate keys: ${truncate(errorKeys.join(', '), 100)}`;
+}
+
+/**
+ * Applies ZodError issues to an event context and replaces the error message
+ */
+function applyZodErrorsToEvent(
+  limit: number,
+  event: Event,
+  saveAttachments?: boolean,
+  hint?: EventHint,
+): Event {
+  if (
+    event.exception === undefined ||
+    event.exception.values === undefined ||
+    hint === undefined ||
+    hint.originalException === undefined ||
+    !originalExceptionIsZodError(hint.originalException) ||
+    hint.originalException.issues.length === 0
+  ) {
+    return event;
+  }
+
+  try {
+    const flattenedIssues = hint.originalException.errors.map(flattenIssue);
+
+    if (saveAttachments === true) {
+      // Add an attachment with all issues (no limits), as well as the default
+      // flatten format to see if it's preferred over our custom flatten format.
+      if (!Array.isArray(hint.attachments)) {
+        hint.attachments = [];
+      }
+      hint.attachments.push({
+        filename: 'zod_issues.json',
+        data: JSON.stringify({
+          issueDetails: hint.originalException.flatten(flattenIssue),
+        }),
+      });
+    }
+
+    return {
+      ...event,
+      exception: {
+        ...event.exception,
+        values: [
+          {
+            ...event.exception.values[0],
+            value: formatIssueMessage(hint.originalException),
+          },
+          ...event.exception.values.slice(1),
+        ],
+      },
+      extra: {
+        ...event.extra,
+        'zoderror.issues': flattenedIssues.slice(0, limit),
+      },
+    };
+  } catch (e) {
+    // Hopefully we never throw errors here, but record it
+    // with the event just in case.
+    return {
+      ...event,
+      extra: {
+        ...event.extra,
+        'zoderrors sentry integration parse error': {
+          message: `an exception was thrown while processing ZodError within applyZodErrorsToEvent()`,
+          error:
+            e instanceof Error
+              ? `${e.name}: ${e.message}\n${e.stack}`
+              : 'unknown',
+        },
+      },
+    };
+  }
+}
+
+/**
+ * Sentry integration to process Zod errors, making them easier to work with in Sentry.
+ */
+export const zodErrorsIntegration = defineIntegration(
+  (options: ZodErrorsOptions = {}) => {
+    const limit = options.limit ?? DEFAULT_LIMIT;
+
+    return {
+      name: INTEGRATION_NAME,
+      processEvent(originalEvent, hint): Event {
+        const processedEvent = applyZodErrorsToEvent(
+          limit,
+          originalEvent,
+          options.saveAttachments,
+          hint,
+        );
+        return processedEvent;
+      },
+    };
+  },
+);

--- a/packages/toucan-js/src/sdk.ts
+++ b/packages/toucan-js/src/sdk.ts
@@ -4,6 +4,7 @@ import { ToucanClient } from './client';
 import {
   linkedErrorsIntegration,
   requestDataIntegration,
+  zodErrorsIntegration,
 } from './integrations';
 import { defaultStackParser } from './stacktrace';
 import { makeFetchTransport } from './transports';
@@ -29,6 +30,7 @@ export class Toucan extends Scope {
               : [
                   requestDataIntegration(options.requestDataOptions),
                   linkedErrorsIntegration(),
+                  zodErrorsIntegration(),
                 ]),
           ];
 


### PR DESCRIPTION
This significantly improves the format of Sentry events for Zod errors (which are really difficult to reason about by default.)