### PR TITLE
chore: Export Zod errors integration and add upstream improvements

### DIFF
--- a/.changeset/itchy-rats-brush.md
+++ b/.changeset/itchy-rats-brush.md
@@ -1,0 +1,8 @@
+---
+'toucan-js': patch
+---
+
+chore: Export Zod errors integration and add upstream improvements
+
+- Adds improvements based on feedback I got while PR'ing this to sentry-javascript: https://github.com/getsentry/sentry-javascript/pull/15111
+- Exports zodErrorsIntegration in the root index.ts (missed this in the original PR)

--- a/packages/toucan-js/src/index.ts
+++ b/packages/toucan-js/src/index.ts
@@ -5,6 +5,7 @@ export {
   extraErrorDataIntegration,
   rewriteFramesIntegration,
   sessionTimingIntegration,
+  zodErrorsIntegration
 } from './integrations';
 export type { LinkedErrorsOptions, RequestDataOptions } from './integrations';
 export { Toucan } from './sdk';


### PR DESCRIPTION
Exports zodErrorsIntegration in the root index.ts (missed this in the original PR)

While I was here, I downstreamed some good feedback that I received in https://github.com/getsentry/sentry-javascript/pull/15111